### PR TITLE
feat: add blog post generator and charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,13 @@ A perfect starting point for building interactive, styled, and edge-deployed SPA
 - 🎨 [shadcn/ui](https://ui.shadcn.com)
 - 💨 [Tailwind CSS Documentation](https://tailwindcss.com/)
 - 🔀 [React Router Docs](https://reactrouter.com/)
+
+## Creating New Blog Posts
+
+Use the provided script to scaffold a new MDX post without typing dates manually:
+
+```bash
+npm run new-post "My Great Take"
+```
+
+This creates a file in `app/content/posts/` with the current date and an example chart component to get you started.

--- a/app/components/BarChart.tsx
+++ b/app/components/BarChart.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+} from "chart.js";
+import { Bar } from "react-chartjs-2";
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
+
+interface Props {
+  labels: string[];
+  data: number[];
+  label?: string;
+}
+
+export default function BarChart({ labels, data, label = "Stats" }: Props) {
+  const chartData = {
+    labels,
+    datasets: [
+      {
+        label,
+        data,
+        backgroundColor: "rgba(59,130,246,0.5)",
+      },
+    ],
+  };
+  const options = {
+    responsive: true,
+    plugins: {
+      legend: { position: "top" as const },
+      title: { display: false },
+    },
+  };
+  return <Bar data={chartData} options={options} />;
+}

--- a/app/content/posts/first-post.mdx
+++ b/app/content/posts/first-post.mdx
@@ -1,0 +1,12 @@
+import BarChart from "../components/BarChart";
+
+export const meta = {
+  title: "First NBA Chart",
+  date: "2025-05-23",
+};
+
+# First NBA Chart
+
+Here is a breakdown of points per quarter:
+
+<BarChart labels={['Q1','Q2','Q3','Q4']} data={[28, 32, 25, 30]} label="Points" />

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -1,3 +1,7 @@
-import { type RouteConfig, index } from "@react-router/dev/routes";
+import { type RouteConfig, index, route } from "@react-router/dev/routes";
 
-export default [index("routes/home.tsx")] satisfies RouteConfig;
+export default [
+  index("routes/home.tsx"),
+  route("blog", "routes/blog.tsx"),
+  route("posts/:slug", "routes/posts.$slug.tsx"),
+] satisfies RouteConfig;

--- a/app/routes/blog.tsx
+++ b/app/routes/blog.tsx
@@ -1,0 +1,28 @@
+import { Link } from "react-router";
+
+const postModules = import.meta.glob("../content/posts/*.mdx", { eager: true });
+
+interface PostMeta {
+  meta?: { title?: string; date?: string };
+}
+
+const posts = Object.entries(postModules).map(([path, module]) => {
+  const slug = path.split("/").pop()?.replace(/\.mdx$/, "") ?? path;
+  const { meta } = module as PostMeta;
+  return { slug, title: meta?.title ?? slug, date: meta?.date };
+});
+
+export default function Blog() {
+  return (
+    <main className="prose dark:prose-invert max-w-none p-4">
+      <h1>Blog</h1>
+      <ul>
+        {posts.map((post) => (
+          <li key={post.slug}>
+            <Link to={`/posts/${post.slug}`}>{post.title}</Link>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/app/routes/posts.$slug.tsx
+++ b/app/routes/posts.$slug.tsx
@@ -1,0 +1,20 @@
+import { useParams } from "react-router";
+
+const postModules = import.meta.glob("../content/posts/*.mdx", { eager: true });
+
+export default function Post() {
+  const { slug } = useParams() as { slug?: string };
+  const key = `../content/posts/${slug}.mdx`;
+  const mod = postModules[key] as { default: React.ComponentType; meta?: { title?: string } } | undefined;
+  if (!mod) {
+    return <main className="p-4">Post not found</main>;
+  }
+  const Component = mod.default;
+  const title = mod.meta?.title ?? slug;
+  return (
+    <main className="prose dark:prose-invert max-w-none p-4">
+      <h1>{title}</h1>
+      <Component />
+    </main>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,11 @@
       "dependencies": {
         "@mdx-js/react": "^3.1.0",
         "@mdx-js/rollup": "^3.1.0",
+        "chart.js": "^4.5.0",
         "hono": "4.8.2",
         "isbot": "5.1.26",
         "react": "19.0.0",
+        "react-chartjs-2": "^5.3.0",
         "react-dom": "19.0.0",
         "react-router": "7.6.3"
       },
@@ -2078,6 +2080,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@mdx-js/mdx": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-3.1.0.tgz",
@@ -3330,6 +3338,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/chokidar": {
@@ -5695,6 +5715,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -19,9 +19,11 @@
   "dependencies": {
     "@mdx-js/react": "^3.1.0",
     "@mdx-js/rollup": "^3.1.0",
+    "chart.js": "^4.5.0",
     "hono": "4.8.2",
     "isbot": "5.1.26",
     "react": "19.0.0",
+    "react-chartjs-2": "^5.3.0",
     "react-dom": "19.0.0",
     "react-router": "7.6.3"
   },
@@ -45,6 +47,7 @@
     "deploy": "npm run build && wrangler deploy",
     "dev": "react-router dev",
     "preview": "npm run build && vite preview",
-    "typecheck": "npm run cf-typegen && react-router typegen && tsc -b"
+    "typecheck": "npm run cf-typegen && react-router typegen && tsc -b",
+    "new-post": "node scripts/new-post.js"
   }
 }

--- a/scripts/new-post.js
+++ b/scripts/new-post.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+import { writeFileSync, mkdirSync, existsSync } from "fs";
+import path from "path";
+
+const title = process.argv[2];
+if (!title) {
+  console.error("Usage: npm run new-post \"Post Title\"");
+  process.exit(1);
+}
+
+const slug = title
+  .toLowerCase()
+  .replace(/[^a-z0-9]+/g, "-")
+  .replace(/(^-|-$)/g, "");
+const date = new Date().toISOString().split("T")[0];
+const dir = path.join(process.cwd(), "app", "content", "posts");
+if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+const filePath = path.join(dir, `${slug}.mdx`);
+const content = `import BarChart from "../components/BarChart";
+
+export const meta = {
+  title: "${title}",
+  date: "${date}",
+};
+
+# ${title}
+
+Write your content here.
+
+<BarChart labels={["Item1","Item2"]} data={[10,20]} label="My Stats" />
+`;
+writeFileSync(filePath, content);
+console.log(`Created ${filePath}`);


### PR DESCRIPTION
## Summary
- add chart.js bar chart component for MDX posts
- list and display posts from content folder
- add script to scaffold new dated posts automatically

## Testing
- `npm run typecheck`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aec5cb5650832e952281fcd18d74e6